### PR TITLE
feat: allow mouse drawing at any zoom level

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ See the [LifeWiki for pattern files](https://conwaylife.com/wiki/Category:Patter
 
 | Key      | Description                               |
 |----------|-------------------------------------------|
-| mouse    | Place cells                               |
+| mouse    | Place/erase cells (works at any zoom)     |
 | `space`  | Play/pause                                |
 | `m`      | Toggle between modes: smart, place, erase |
 | `wasd`   | Move the game board                       |

--- a/internal/game/conway/conway.go
+++ b/internal/game/conway/conway.go
@@ -90,25 +90,8 @@ func (c *Conway) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		mouse := msg.Mouse()
 		switch msg.(type) {
 		case tea.MouseClickMsg, tea.MouseMotionMsg:
-			if mouse.Button == tea.MouseLeft && c.level == 0 {
-				mouse.X = mouse.X/2 + c.view.X
-				mouse.Y += c.view.Y
-				switch c.mode {
-				case ModeSmart:
-					if c.smartVal == -1 {
-						val := c.Pattern.Tree.Get(image.Pt(mouse.X, mouse.Y))
-						if val {
-							c.smartVal = 0
-						} else {
-							c.smartVal = 1
-						}
-					}
-					c.Pattern.Tree.Set(image.Pt(mouse.X, mouse.Y), c.smartVal)
-				case ModePlace:
-					c.Pattern.Tree.Set(image.Pt(mouse.X, mouse.Y), 1)
-				case ModeErase:
-					c.Pattern.Tree.Set(image.Pt(mouse.X, mouse.Y), 0)
-				}
+			if mouse.Button == tea.MouseLeft {
+				c.paintAtMouse(mouse.X, mouse.Y)
 			}
 		case tea.MouseWheelMsg:
 			switch mouse.Button {
@@ -273,6 +256,59 @@ func (c *Conway) center() {
 	size := c.Pattern.Tree.FilledCoords().Size()
 	c.view.X = size.X/2 - c.gameSize.X/2
 	c.view.Y = size.Y/2 - c.gameSize.Y/2
+}
+
+// mouseToWorldRect maps a terminal mouse position to the world-space rectangle
+// covered by that screen cell at the current zoom level. Each screen cell is two
+// columns wide; zoom level N maps one screen cell to a (1<<N)×(1<<N) block.
+func (c *Conway) mouseToWorldRect(mouseX, mouseY int) image.Rectangle {
+	skip := 1 << c.level
+	x := c.view.X + (mouseX/2)*skip
+	y := c.view.Y + mouseY*skip
+	return image.Rect(x, y, x+skip, y+skip)
+}
+
+func (c *Conway) regionHasAlive(rect image.Rectangle) bool {
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			if c.Pattern.Tree.Get(image.Pt(x, y)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Conway) fillRegion(rect image.Rectangle, value int) {
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			c.Pattern.Tree.Set(image.Pt(x, y), value)
+		}
+	}
+}
+
+// paintAtMouse places or erases cells under the cursor. When zoomed out, the
+// whole visible block is painted so the change stays visible at that zoom.
+func (c *Conway) paintAtMouse(mouseX, mouseY int) {
+	if c.Pattern == nil {
+		return
+	}
+	rect := c.mouseToWorldRect(mouseX, mouseY)
+	switch c.mode {
+	case ModeSmart:
+		if c.smartVal == -1 {
+			if c.regionHasAlive(rect) {
+				c.smartVal = 0
+			} else {
+				c.smartVal = 1
+			}
+		}
+		c.fillRegion(rect, c.smartVal)
+	case ModePlace:
+		c.fillRegion(rect, 1)
+	case ModeErase:
+		c.fillRegion(rect, 0)
+	}
 }
 
 func (c *Conway) Play() tea.Cmd {

--- a/internal/game/conway/conway_test.go
+++ b/internal/game/conway/conway_test.go
@@ -1,14 +1,94 @@
 package conway
 
 import (
+	"image"
 	"testing"
 	"time"
 
 	"gabe565.com/cli-of-life/internal/config"
+	"gabe565.com/cli-of-life/internal/pattern"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultSpeed(t *testing.T) {
 	conway := NewConway(config.New())
 	assert.Equal(t, time.Second/30, speeds[conway.speed])
+}
+
+func TestMouseToWorldRect(t *testing.T) {
+	c := NewConway(config.New())
+	c.view = image.Pt(10, 20)
+
+	t.Run("zoom level 0 maps one screen cell to one world cell", func(t *testing.T) {
+		c.level = 0
+		assert.Equal(t, image.Rect(12, 25, 13, 26), c.mouseToWorldRect(4, 5))
+		assert.Equal(t, image.Rect(12, 25, 13, 26), c.mouseToWorldRect(5, 5))
+	})
+
+	t.Run("zoom level 2 maps one screen cell to a 4x4 block", func(t *testing.T) {
+		c.level = 2
+		assert.Equal(t, image.Rect(18, 28, 22, 32), c.mouseToWorldRect(4, 2))
+	})
+}
+
+func TestPaintAtMouseZoomedOut(t *testing.T) {
+	c := NewConway(config.New())
+	c.Pattern = pattern.Default()
+	c.view = image.Pt(0, 0)
+	c.level = 2
+	c.mode = ModePlace
+
+	c.paintAtMouse(2, 1) // screen cell (1,1) -> world [4,8) x [4,8)
+
+	for y := 4; y < 8; y++ {
+		for x := 4; x < 8; x++ {
+			assert.True(t, c.Pattern.Tree.Get(image.Pt(x, y)), "expected alive at (%d,%d)", x, y)
+		}
+	}
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(3, 4)))
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(4, 3)))
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(8, 4)))
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(4, 8)))
+}
+
+func TestPaintAtMouseSmartToggleZoomedOut(t *testing.T) {
+	c := NewConway(config.New())
+	c.Pattern = pattern.Default()
+	c.view = image.Pt(0, 0)
+	c.level = 1
+	c.mode = ModeSmart
+
+	c.Pattern.Tree.Set(image.Pt(2, 2), 1)
+	require.True(t, c.Pattern.Tree.Get(image.Pt(2, 2)))
+
+	c.paintAtMouse(2, 1) // screen cell (1,1) -> world [2,4) x [2,4)
+	assert.Equal(t, 0, c.smartVal)
+	for y := 2; y < 4; y++ {
+		for x := 2; x < 4; x++ {
+			assert.False(t, c.Pattern.Tree.Get(image.Pt(x, y)))
+		}
+	}
+
+	c.smartVal = -1
+	c.paintAtMouse(2, 1)
+	assert.Equal(t, 1, c.smartVal)
+	for y := 2; y < 4; y++ {
+		for x := 2; x < 4; x++ {
+			assert.True(t, c.Pattern.Tree.Get(image.Pt(x, y)))
+		}
+	}
+}
+
+func TestPaintAtMouseLevelZeroUnchanged(t *testing.T) {
+	c := NewConway(config.New())
+	c.Pattern = pattern.Default()
+	c.view = image.Pt(10, 20)
+	c.level = 0
+	c.mode = ModePlace
+
+	c.paintAtMouse(4, 5) // -> (12, 25)
+	assert.True(t, c.Pattern.Tree.Get(image.Pt(12, 25)))
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(13, 25)))
+	assert.False(t, c.Pattern.Tree.Get(image.Pt(12, 26)))
 }


### PR DESCRIPTION
## Summary
- Enable mouse place/erase at every zoom level (previously zoom 0 only).
- Map terminal clicks through `1<<zoom` and paint the full visible world block so edits stay visible when zoomed out.
- Keep zoom-0 single-cell behavior; tests cover mapping, zoomed fill, smart toggle, and level-0 regression.

## Why
Drawing was disabled whenever the board was zoomed out, which blocked editing overview views.

## Verification
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./internal/game/conway/...` — 0 issues
- [x] full-review Round 2 — APPROVE — IMPLEMENTATION_READY


Made with [Cursor](https://cursor.com)