### PR TITLE
Add ability to save patterns to file

### DIFF
--- a/internal/game/menu/buttons.go
+++ b/internal/game/menu/buttons.go
@@ -19,6 +19,8 @@ func (m *Menu) handleButtonPress(btn *buttons.Button) tea.Cmd {
 		return commands.ChangeView(commands.Conway)
 	case BtnLoad:
 		return m.loadPatternForm()
+	case BtnSave:
+		return m.savePatternForm()
 	case BtnQuit:
 		return tea.Quit
 	default:

--- a/internal/game/menu/forms.go
+++ b/internal/game/menu/forms.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -147,6 +148,37 @@ func (m *Menu) patternURLForm() tea.Cmd {
 				Accessor(&trimSpaceAccessor{&m.config.Pattern}),
 		),
 	)
+	return m.initForm()
+}
+
+func (m *Menu) savePatternForm() tea.Cmd {
+	ne := huh.ValidateNotEmpty()
+	m.saveFilename = ""
+	m.form = util.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Save Pattern As").
+				Description("  Enter a file path. Extension defaults to .rle\n  (use .cells for the plaintext format).\n").
+				Placeholder("pattern" + pattern.ExtRLE).
+				Validate(func(s string) error {
+					if err := ne(s); err != nil {
+						return err
+					}
+					if strings.Contains(s, "\n") {
+						return ErrLineBreak
+					}
+					return nil
+				}).
+				Accessor(&trimSpaceAccessor{&m.saveFilename}),
+		),
+	)
+	m.onFormComplete = func() tea.Cmd {
+		ext := filepath.Ext(m.saveFilename)
+		if ext != pattern.ExtRLE && ext != pattern.ExtPlaintext {
+			m.saveFilename += pattern.ExtRLE
+		}
+		return m.SavePattern()
+	}
 	return m.initForm()
 }
 

--- a/internal/game/menu/menu.go
+++ b/internal/game/menu/menu.go
@@ -32,6 +32,7 @@ const (
 	BtnReset  = "Reset Game"
 	BtnNew    = "New Game"
 	BtnLoad   = "Load Pattern"
+	BtnSave   = "Save Pattern"
 	BtnQuit   = "Quit"
 )
 
@@ -44,10 +45,11 @@ func NewMenu(conf *config.Config, conway *conway.Conway) *Menu {
 		styles: newStyles(),
 
 		conway:  conway,
-		buttons: buttons.New(BtnResume, BtnReset, BtnNew, BtnLoad, BtnQuit),
+		buttons: buttons.New(BtnResume, BtnReset, BtnNew, BtnLoad, BtnSave, BtnQuit),
 	}
 	m.buttons.List[0].Hidden = true
 	m.buttons.List[1].Hidden = true
+	m.buttons.List[4].Hidden = true
 	return m
 }
 
@@ -63,6 +65,9 @@ type Menu struct {
 	buttons    *buttons.Buttons
 	form       *huh.Form
 	patternSrc string
+
+	saveFilename   string
+	onFormComplete func() tea.Cmd
 
 	error error
 }
@@ -94,6 +99,11 @@ func (m *Menu) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.form.State {
 		case huh.StateCompleted:
 			m.form = nil
+			if m.onFormComplete != nil {
+				cmd := m.onFormComplete
+				m.onFormComplete = nil
+				return m, cmd()
+			}
 			defer func() {
 				m.patternSrc = ""
 			}()
@@ -110,6 +120,7 @@ func (m *Menu) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case huh.StateAborted:
 			m.form = nil
+			m.onFormComplete = nil
 			return m, nil
 		default:
 			return m, cmd
@@ -122,6 +133,7 @@ func (m *Menu) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			empty := m.conway.Pattern.Tree.IsEmpty()
 			m.buttons.List[0].Hidden = empty
 			m.buttons.List[1].Hidden = empty
+			m.buttons.List[4].Hidden = empty
 			m.buttons.Active = 0
 		}
 	case tea.KeyPressMsg:
@@ -174,6 +186,15 @@ func (m *Menu) LoadPattern() tea.Cmd {
 	m.conway.Pattern = p
 	m.conway.ResetView()
 	return commands.ChangeView(commands.Conway)
+}
+
+func (m *Menu) SavePattern() tea.Cmd {
+	if err := pattern.MarshalFile(m.saveFilename, m.conway.Pattern); err != nil {
+		m.error = err
+	} else {
+		m.error = nil
+	}
+	return nil
 }
 
 func (m *Menu) SetDark(dark bool) {

--- a/internal/pattern/pattern.go
+++ b/internal/pattern/pattern.go
@@ -103,6 +103,24 @@ func UnmarshalFile(path string) (*Pattern, error) {
 	}
 }
 
+func MarshalFile(path string, p *Pattern) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	ext := filepath.Ext(path)
+	switch ext {
+	case ExtPlaintext:
+		return MarshalPlaintext(f, p)
+	default:
+		return MarshalRLE(f, p)
+	}
+}
+
 var ErrResponse = errors.New("HTTP error")
 
 func UnmarshalURL(ctx context.Context, url string) (*Pattern, error) {

--- a/internal/pattern/plaintext.go
+++ b/internal/pattern/plaintext.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image"
 	"io"
+	"strings"
 )
 
 func UnmarshalPlaintext(r io.Reader) (*Pattern, error) {
@@ -49,4 +50,44 @@ func UnmarshalPlaintext(r io.Reader) (*Pattern, error) {
 	}
 	pattern.Tree.SetReset()
 	return pattern, nil
+}
+
+func MarshalPlaintext(w io.Writer, p *Pattern) error {
+	bw := bufio.NewWriter(w)
+
+	if p.Name != "" {
+		if _, err := fmt.Fprintf(bw, "!Name: %s\n", p.Name); err != nil {
+			return err
+		}
+	}
+	if p.Author != "" {
+		if _, err := fmt.Fprintf(bw, "!Author: %s\n", p.Author); err != nil {
+			return err
+		}
+	}
+	for _, line := range strings.Split(p.Comment, "\n") {
+		if line == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(bw, "!%s\n", line); err != nil {
+			return err
+		}
+	}
+
+	for _, row := range p.Tree.ToSlice() {
+		line := make([]byte, len(row))
+		for x, v := range row {
+			if v != 0 {
+				line[x] = 'O'
+			} else {
+				line[x] = '.'
+			}
+		}
+		line = append(line, '\n')
+		if _, err := bw.Write(line); err != nil {
+			return err
+		}
+	}
+
+	return bw.Flush()
 }

--- a/internal/pattern/rle.go
+++ b/internal/pattern/rle.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"gabe565.com/cli-of-life/internal/rule"
 )
@@ -115,4 +116,104 @@ scan:
 	}
 	pattern.Tree.SetReset()
 	return pattern, nil
+}
+
+const rleLineLength = 70
+
+func MarshalRLE(w io.Writer, p *Pattern) error {
+	bw := bufio.NewWriter(w)
+
+	if p.Name != "" {
+		if _, err := fmt.Fprintf(bw, "#N %s\n", p.Name); err != nil {
+			return err
+		}
+	}
+	if p.Author != "" {
+		if _, err := fmt.Fprintf(bw, "#O %s\n", p.Author); err != nil {
+			return err
+		}
+	}
+	for _, line := range strings.Split(p.Comment, "\n") {
+		if line == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(bw, "#C %s\n", line); err != nil {
+			return err
+		}
+	}
+
+	grid := p.Tree.ToSlice()
+	height := len(grid)
+	width := 0
+	if height != 0 {
+		width = len(grid[0])
+	}
+
+	if _, err := fmt.Fprintf(bw, "x = %d, y = %d, rule = %s\n", width, height, p.Rule.String()); err != nil {
+		return err
+	}
+
+	var tokens []string
+	for y, row := range grid {
+		runChar := byte(0)
+		runCount := 0
+		flush := func() {
+			if runCount == 0 {
+				return
+			}
+			c := byte('b')
+			if runChar != 0 {
+				c = 'o'
+			}
+			token := string(c)
+			if runCount > 1 {
+				token = strconv.Itoa(runCount) + token
+			}
+			tokens = append(tokens, token)
+			runCount = 0
+		}
+
+		for _, v := range row {
+			c := byte(0)
+			if v != 0 {
+				c = 1
+			}
+			if runCount > 0 && c != runChar {
+				flush()
+			}
+			runChar = c
+			runCount++
+		}
+		if runChar != 0 {
+			flush()
+		} else {
+			runCount = 0
+		}
+
+		if y < height-1 {
+			tokens = append(tokens, "$")
+		}
+	}
+	tokens = append(tokens, "!")
+
+	var lineLen int
+	for i, token := range tokens {
+		if lineLen != 0 && lineLen+len(token) > rleLineLength {
+			if _, err := bw.WriteString("\n"); err != nil {
+				return err
+			}
+			lineLen = 0
+		}
+		if _, err := bw.WriteString(token); err != nil {
+			return err
+		}
+		lineLen += len(token)
+		if i == len(tokens)-1 {
+			if _, err := bw.WriteString("\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return bw.Flush()
 }


### PR DESCRIPTION
## Summary
- Add `MarshalRLE` and `MarshalPlaintext` to encode a `Pattern` back to the RLE (`.rle`) and plaintext (`.cells`) formats, including name/author/comment metadata
- Add `pattern.MarshalFile` to write to a path, choosing the format from the file extension (mirrors the existing `UnmarshalFile`)
- Add a "Save Pattern" menu option (shown alongside Reset/Resume whenever the board isn't empty) that prompts for a filename and writes the current pattern to disk

This lets patterns drawn or edited in the terminal (smart/place/erase modes) be saved, rather than only ever being loadable from a pre-existing file or URL.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manual round-trip check: parsed the embedded glider RLE, marshaled it back out, re-parsed it, and confirmed the grid matches; output matches the canonical RLE/plaintext layout
- [x] Manual run: drew a pattern in-game, saved via the new menu option, confirmed the file loads back correctly